### PR TITLE
Add "downloadUrlPrefix"

### DIFF
--- a/src/main/java/dev/bmac/gradle/intellij/UploadPluginTask.java
+++ b/src/main/java/dev/bmac/gradle/intellij/UploadPluginTask.java
@@ -5,7 +5,6 @@ import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.*;
 
 import javax.inject.Inject;
@@ -16,6 +15,10 @@ public class UploadPluginTask extends ConventionTask {
     //The (encoded) url of the repository where updatePlugins.xml and the plugin zips will be placed
     @Input
     public final Property<String> url;
+    //Prefix of download urls in updatePlugins.xml (optional)
+    @Input
+    @Optional
+    public final Property<String> downloadUrlPrefix;
     //Use absolute path for the download url in update plugins xml ($url/$pluginName/${file.getName})
     @Input
     @Optional
@@ -78,6 +81,7 @@ public class UploadPluginTask extends ConventionTask {
     public UploadPluginTask(ObjectFactory objectFactory) {
         url = objectFactory.property(String.class);
         absoluteDownloadUrls = objectFactory.property(Boolean.class);
+        downloadUrlPrefix = objectFactory.property(String.class);
         pluginName = objectFactory.property(String.class);
         file = objectFactory.fileProperty();
         updateFile = objectFactory.property(String.class);
@@ -119,6 +123,7 @@ public class UploadPluginTask extends ConventionTask {
 
         new PluginUploader(1000, 5, logger,
                 url.get(),
+                downloadUrlPrefix.getOrNull(),
                 absoluteDownloadUrls.getOrElse(false),
                 pluginName.get(),
                 file.get().getAsFile(),
@@ -138,6 +143,10 @@ public class UploadPluginTask extends ConventionTask {
 
     public Property<String> getUrl() {
         return url;
+    }
+
+    public Property<String> getDownloadUrlPrefix() {
+        return downloadUrlPrefix;
     }
 
     public Property<Boolean> getAbsoluteDownloadUrls() {

--- a/src/test/java/dev/bmac/gradle/intellij/PluginUploaderBuilder.java
+++ b/src/test/java/dev/bmac/gradle/intellij/PluginUploaderBuilder.java
@@ -8,6 +8,7 @@ import java.io.File;
 public class PluginUploaderBuilder {
 
     private String url;
+    private String downloadUrlPrefix;
     private boolean absoluteDownloadUrls = false;
     private String pluginName;
     private File file;
@@ -40,6 +41,11 @@ public class PluginUploaderBuilder {
 
     public PluginUploaderBuilder setUrl(String url) {
         this.url = url;
+        return this;
+    }
+
+    public PluginUploaderBuilder setDownloadUrlPrefix(final String downloadUrlPrefix) {
+        this.downloadUrlPrefix = downloadUrlPrefix;
         return this;
     }
 
@@ -121,6 +127,10 @@ public class PluginUploaderBuilder {
         return url;
     }
 
+    public String getDownloadUrlPrefix() {
+        return downloadUrlPrefix;
+    }
+
     public boolean isAbsoluteDownloadUrls() {
         return absoluteDownloadUrls;
     }
@@ -178,9 +188,9 @@ public class PluginUploaderBuilder {
     }
 
     public PluginUploader build(String lockId) throws Exception {
-        return new PluginUploader(1, 2, logger, url, absoluteDownloadUrls, pluginName, file,
-                updateFile, pluginId, version, authentication, description, changeNotes, updatePluginXml,
-                sinceBuild, untilBuild, repoType, blockmapFile, hashFile) {
+        return new PluginUploader(1, 2, logger, url, downloadUrlPrefix, absoluteDownloadUrls,
+                pluginName, file, updateFile, pluginId, version, authentication, description, changeNotes,
+                updatePluginXml, sinceBuild, untilBuild, repoType, blockmapFile, hashFile) {
             @Override
             protected String getLockId() {
                 return lockId;


### PR DESCRIPTION
Add "downloadUrlPrefix" property that allows you to configure the prefix of generated download URLs in updatePlugins.xml.

`absoluateDownloadUrls` flag added in #7 wasn't flexible enough for me. 
In my case, I'm uploading plugins to a private non-AWS S3 endpoint, which can then be accessed via a public HTTPS link with a completely different URL than the upload URL.
Generated relative links don't work in my case either (for example, I get a non working relative link `url="./hh-geminio/hh-geminio.zip"` although a relative link like `url="hh-geminio/hh-geminio.zip"` or `url="/hh-geminio/hh-geminio.zip"` would work).

Maybe customization of the URL prefix can also be useful in some other cases.